### PR TITLE
feat: embed static files in binary

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zaibon/shortcut/db"
 	"github.com/zaibon/shortcut/handlers"
 	"github.com/zaibon/shortcut/services"
+	"github.com/zaibon/shortcut/static"
 )
 
 type config struct {
@@ -35,7 +36,7 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.RealIP)
 
-	fs := http.FileServer(http.Dir("static"))
+	fs := http.FileServer(static.FileSystem)
 	r.Handle("/static/*", http.StripPrefix("/static/", fs))
 
 	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))

--- a/generate.go
+++ b/generate.go
@@ -1,3 +1,3 @@
-package components
+package shortcut
 
 //go:generate templ generate ./...

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ build-linux: generate fmt
     CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o bin/shortcut-linux cmd/main.go
 
 build-dev: generate
-    go build -o bin/shortcut cmd/main.go
+    go build -tags=dev -o bin/shortcut cmd/main.go
 
 run: build
     ./bin/shortcut

--- a/static/file_server.go
+++ b/static/file_server.go
@@ -1,0 +1,17 @@
+//go:build !dev
+
+package static
+
+import (
+	"embed"
+	"net/http"
+)
+
+//go:embed img
+var staticAssets embed.FS
+
+var FileSystem http.FileSystem
+
+func init() {
+	FileSystem = http.FS(staticAssets)
+}

--- a/static/file_server_dev.go
+++ b/static/file_server_dev.go
@@ -1,0 +1,13 @@
+//go:build dev
+
+package static
+
+import (
+	"net/http"
+)
+
+var FileSystem http.FileSystem
+
+func init() {
+	FileSystem = http.Dir("./static")
+}


### PR DESCRIPTION
Store the static files into the binaries when built for production. In dev mode, serve the files from the local filesystem.