### PR TITLE
feat: URL safety scanner and admin threat moderation board

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,6 +90,14 @@ func main() {
 				},
 				Flags: migrationScan,
 			},
+			{
+				Name:  "scan-urls",
+				Usage: "bulk scans existing shortened URLs against Google Web Risk API",
+				Action: func(ctx *cli.Context) error {
+					return runScanURLs(ctx, c)
+				},
+				Flags: scanURLFlags,
+			},
 		},
 	}
 

--- a/cmd/scan_urls.go
+++ b/cmd/scan_urls.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/joho/godotenv"
+	"github.com/urfave/cli/v2"
+
+	"github.com/zaibon/shortcut/db"
+	"github.com/zaibon/shortcut/domain"
+	"github.com/zaibon/shortcut/log"
+	"github.com/zaibon/shortcut/services"
+)
+
+var (
+	envFile     string
+	dryRun      bool
+	onlyActive  bool
+	scanLimit   int
+	scanDelayMs int
+)
+
+var scanURLFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:        "env-file",
+		Usage:       "path to env file (e.g. .env-prod) to overload environment variables",
+		Value:       "",
+		Destination: &envFile,
+	},
+	&cli.BoolFlag{
+		Name:        "dry-run",
+		Usage:       "if true, only scans and logs threats without making database changes",
+		Value:       true,
+		Destination: &dryRun,
+	},
+	&cli.BoolFlag{
+		Name:        "only-active",
+		Usage:       "if true, only scans URLs that are active and not archived",
+		Value:       true,
+		Destination: &onlyActive,
+	},
+	&cli.IntFlag{
+		Name:        "limit",
+		Usage:       "maximum number of URLs to scan (0 for unlimited)",
+		Value:       0,
+		Destination: &scanLimit,
+	},
+	&cli.IntFlag{
+		Name:        "delay",
+		Usage:       "delay between API calls in milliseconds",
+		Value:       100,
+		Destination: &scanDelayMs,
+	},
+	&cli.StringFlag{
+		Name:        "db",
+		Usage:       "database connection string",
+		Value:       "",
+		Destination: &c.DBConnString,
+	},
+	&cli.StringFlag{
+		Name:        "webrisk-key",
+		Usage:       "Google Web Risk API Key",
+		Value:       "",
+		Destination: &c.GoogleWebRiskAPIKey,
+	},
+}
+
+func runScanURLs(cCtx *cli.Context, cfg config) error {
+	// 1. Env Overloading
+	if envFile != "" {
+		log.Info("Loading environment file", "path", envFile)
+		if err := godotenv.Overload(envFile); err != nil {
+			return fmt.Errorf("failed to load env file %s: %w", envFile, err)
+		}
+	}
+
+	// 2. Fetch config values from env if they were not explicitly passed via CLI flags
+	dbString := cfg.DBConnString
+	if dbString == "" {
+		dbString = os.Getenv("SHORTCUT_DB")
+	}
+
+	webRiskAPIKey := cfg.GoogleWebRiskAPIKey
+	if webRiskAPIKey == "" {
+		webRiskAPIKey = os.Getenv("SHORTCUT_GOOGLE_WEBRISK_API_KEY")
+	}
+
+	if dbString == "" {
+		return fmt.Errorf("database connection string is empty (specify via --db or SHORTCUT_DB env var)")
+	}
+
+	ctx := context.Background()
+
+	// Create a temporary masked config to output redacted connection strings safely
+	tempConfig := config{DBConnString: dbString}
+	log.Info("Connecting to database...", "dsn", tempConfig.SafeDBString())
+
+	dbPool, err := pgxpool.New(ctx, dbString)
+	if err != nil {
+		return fmt.Errorf("unable to connect to database: %w", err)
+	}
+	defer dbPool.Close()
+
+	if err := dbPool.Ping(ctx); err != nil {
+		return fmt.Errorf("unable to ping database: %w", err)
+	}
+
+	// 3. Fetch active URLs
+	query := "SELECT id, title, short_url, long_url, author_id, is_active FROM urls"
+	var args []any
+
+	if onlyActive {
+		query += " WHERE is_active = true AND is_archived = false"
+	}
+
+	query += " ORDER BY id ASC"
+
+	if scanLimit > 0 {
+		query += " LIMIT $1"
+		args = append(args, scanLimit)
+	}
+
+	rows, err := dbPool.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query URLs: %w", err)
+	}
+	defer rows.Close()
+
+	type URLItem struct {
+		ID       int32
+		Title    string
+		ShortURL string
+		LongURL  string
+		AuthorID int32
+		IsActive bool
+	}
+
+	var items []URLItem
+	for rows.Next() {
+		var item URLItem
+		if err := rows.Scan(&item.ID, &item.Title, &item.ShortURL, &item.LongURL, &item.AuthorID, &item.IsActive); err != nil {
+			return fmt.Errorf("failed to scan URL row: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("rows error: %w", err)
+	}
+
+	log.Info("Query completed", "count", len(items))
+
+	// 4. Initialize Safety Scanner & URL Store
+	if webRiskAPIKey == "" {
+		log.Warn("Google Web Risk API Key is empty. Standard Web Risk API scans will be skipped, running only local heuristics.")
+	}
+
+	scanner := services.NewWebRiskScanner(webRiskAPIKey)
+	urlStore := db.NewURLStore(dbPool)
+
+	// 5. Run loop and scan URLs
+	var scannedCount, flaggedCount, errorCount int
+
+	for i, item := range items {
+		log.Info(fmt.Sprintf("[%d/%d] Scanning short_url=%s long_url=%s", i+1, len(items), item.ShortURL, item.LongURL))
+
+		riskScore, threatType, err := scanner.Scan(ctx, item.LongURL)
+		scannedCount++
+		if err != nil {
+			log.Error("Error scanning URL", "url", item.LongURL, "err", err)
+			errorCount++
+			continue
+		}
+
+		if threatType != "" || riskScore > 0 {
+			flaggedCount++
+			log.Warn("THREAT DETECTED!", "url", item.LongURL, "threat", threatType, "score", riskScore, "author_id", item.AuthorID)
+
+			if dryRun {
+				log.Info(fmt.Sprintf("[DRY RUN] Would deactivate URL %s, insert moderation flag, and suspend user ID %d", item.ShortURL, item.AuthorID))
+			} else {
+				log.Info(fmt.Sprintf("Applying moderation action for URL %s...", item.ShortURL))
+
+				// 1. Deactivate URL
+				if err := urlStore.UpdateURLStatus(ctx, item.ShortURL, false); err != nil {
+					log.Error("Failed to deactivate URL", "short_url", item.ShortURL, "err", err)
+					errorCount++
+					continue
+				}
+				log.Info("Successfully deactivated URL", "short_url", item.ShortURL)
+
+				// 2. Insert Moderation Flag
+				if err := urlStore.InsertModerationFlag(ctx, domain.ID(item.ID), domain.ID(item.AuthorID), riskScore, threatType); err != nil {
+					log.Error("Failed to insert moderation flag", "url_id", item.ID, "err", err)
+					errorCount++
+					// Continue anyway since URL is deactivated
+				} else {
+					log.Info("Successfully logged moderation flag in DB", "url_id", item.ID)
+				}
+
+				// 3. Suspend Creator
+				if err := urlStore.SuspendUserByID(ctx, domain.ID(item.AuthorID), true); err != nil {
+					log.Error("Failed to suspend user", "user_id", item.AuthorID, "err", err)
+					errorCount++
+				} else {
+					log.Info("Successfully suspended offending user account", "user_id", item.AuthorID)
+				}
+			}
+		}
+
+		if scanDelayMs > 0 && i < len(items)-1 {
+			time.Sleep(time.Duration(scanDelayMs) * time.Millisecond)
+		}
+	}
+
+	log.Info("Scan complete!", "total_scanned", scannedCount, "flagged", flaggedCount, "errors", errorCount)
+	return nil
+}

--- a/db/datastore/moderation.sql.go
+++ b/db/datastore/moderation.sql.go
@@ -82,6 +82,7 @@ SELECT
     f.reviewed_by,
     urls.long_url,
     urls.short_url,
+    users.guid,
     users.username,
     users.email
 FROM moderation_flags f
@@ -102,6 +103,7 @@ type ListModerationFlagsRow struct {
 	ReviewedBy pgtype.UUID      `json:"reviewed_by"`
 	LongUrl    string           `json:"long_url"`
 	ShortUrl   string           `json:"short_url"`
+	Guid       pgtype.UUID      `json:"guid"`
 	Username   string           `json:"username"`
 	Email      string           `json:"email"`
 }
@@ -127,6 +129,7 @@ func (q *Queries) ListModerationFlags(ctx context.Context) ([]ListModerationFlag
 			&i.ReviewedBy,
 			&i.LongUrl,
 			&i.ShortUrl,
+			&i.Guid,
 			&i.Username,
 			&i.Email,
 		); err != nil {

--- a/db/queries/moderation.sql
+++ b/db/queries/moderation.sql
@@ -16,6 +16,7 @@ SELECT
     f.reviewed_by,
     urls.long_url,
     urls.short_url,
+    users.guid,
     users.username,
     users.email
 FROM moderation_flags f

--- a/domain/admin.go
+++ b/domain/admin.go
@@ -67,6 +67,7 @@ type ModerationFlag struct {
 	ID          int
 	URLID       int
 	UserID      int
+	UserGUID    GUID
 	RiskScore   int
 	ThreatType  string
 	Status      string

--- a/services/administration.go
+++ b/services/administration.go
@@ -637,6 +637,7 @@ func (s *Administration) ListModerationFlags(ctx context.Context) ([]domain.Mode
 			ID:         int(r.ID),
 			URLID:      int(r.UrlID),
 			UserID:     int(r.UserID),
+			UserGUID:   domain.GUID(r.Guid.Bytes),
 			RiskScore:  int(r.RiskScore),
 			ThreatType: r.ThreatType,
 			Status:     r.Status,

--- a/templates/admin/moderation.templ
+++ b/templates/admin/moderation.templ
@@ -83,7 +83,9 @@ templ ModerationRow(flag domain.ModerationFlag) {
 		<!-- Creator/User details -->
 		<td class="px-6 py-4 whitespace-nowrap">
 			<div class="flex flex-col">
-				<span class="text-sm font-medium text-gray-900">{ flag.Username }</span>
+				<a href={ templ.SafeURL(fmt.Sprintf("/admin/users/%s", flag.UserGUID)) } class="text-sm font-medium text-indigo-600 hover:text-indigo-900 hover:underline transition-all">
+					{ flag.Username }
+				</a>
 				<span class="text-xs text-gray-500">{ flag.Email }</span>
 			</div>
 		</td>

--- a/templates/admin/moderation_templ.go
+++ b/templates/admin/moderation_templ.go
@@ -187,189 +187,202 @@ func ModerationRow(flag domain.ModerationFlag) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div></td><!-- Creator/User details --><td class=\"px-6 py-4 whitespace-nowrap\"><div class=\"flex flex-col\"><span class=\"text-sm font-medium text-gray-900\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div></td><!-- Creator/User details --><td class=\"px-6 py-4 whitespace-nowrap\"><div class=\"flex flex-col\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(flag.Username)
+		var templ_7745c5c3_Var9 templ.SafeURL
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/admin/users/%s", flag.UserGUID)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 86, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 86, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</span> <span class=\"text-xs text-gray-500\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"text-sm font-medium text-indigo-600 hover:text-indigo-900 hover:underline transition-all\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(flag.Email)
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(flag.Username)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 87, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 87, Col: 20}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span></div></td><!-- Risk Score & Threat Type --><td class=\"px-6 py-4 whitespace-nowrap\"><div class=\"flex flex-col space-y-1\"><div class=\"flex items-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</a> <span class=\"text-xs text-gray-500\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(flag.Email)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 89, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span></div></td><!-- Risk Score & Threat Type --><td class=\"px-6 py-4 whitespace-nowrap\"><div class=\"flex flex-col space-y-1\"><div class=\"flex items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if flag.RiskScore >= 80 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<span class=\"inline-flex items-center px-2 py-0.5 rounded text-xs font-bold bg-red-100 text-red-800\"><i class=\"fas fa-exclamation-triangle mr-1\"></i> Score: ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", flag.RiskScore))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 97, Col: 98}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span class=\"inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-yellow-100 text-yellow-800\"><i class=\"fas fa-exclamation-circle mr-1\"></i> Score: ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span class=\"inline-flex items-center px-2 py-0.5 rounded text-xs font-bold bg-red-100 text-red-800\"><i class=\"fas fa-exclamation-triangle mr-1\"></i> Score: ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", flag.RiskScore))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 101, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 99, Col: 98}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div class=\"text-xs text-gray-600 font-medium flex items-center\"><i class=\"fas fa-virus text-gray-400 mr-1 text-[10px]\"></i> ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var13 string
-		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(flag.ThreatType)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 106, Col: 82}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div></td><!-- Status Badge --><td class=\"px-6 py-4 whitespace-nowrap\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if flag.Status == "flagged" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span class=\"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800\"><i class=\"fas fa-hourglass-half mr-1 text-[10px]\"></i> Pending Review</span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else if flag.Status == "approved" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800\"><i class=\"fas fa-check-circle mr-1 text-[10px]\"></i> Approved (Safe)</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800\"><i class=\"fas fa-times-circle mr-1 text-[10px]\"></i> Rejected (Banned)</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<span class=\"inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-yellow-100 text-yellow-800\"><i class=\"fas fa-exclamation-circle mr-1\"></i> Score: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", flag.RiskScore))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 103, Col: 96}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</td><!-- Flagged date --><td class=\"px-6 py-4 whitespace-nowrap text-sm text-gray-500 font-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div><div class=\"text-xs text-gray-600 font-medium flex items-center\"><i class=\"fas fa-virus text-gray-400 mr-1 text-[10px]\"></i> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
-		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(flag.CreatedAt.Format("2006-01-02 15:04:05"))
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(flag.ThreatType)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 130, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 108, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</td><!-- Actions --><td class=\"px-6 py-4 whitespace-nowrap text-right text-sm font-medium\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></div></td><!-- Status Badge --><td class=\"px-6 py-4 whitespace-nowrap\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if flag.Status == "flagged" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"flex justify-end space-x-2\"><button hx-post=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800\"><i class=\"fas fa-hourglass-half mr-1 text-[10px]\"></i> Pending Review</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var15 string
-			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/admin/moderation/%d/review", flag.ID))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 138, Col: 67}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		} else if flag.Status == "approved" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800\"><i class=\"fas fa-check-circle mr-1 text-[10px]\"></i> Approved (Safe)</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" hx-vals='{\"status\": \"approved\"}' hx-target=\"closest tr\" hx-swap=\"outerHTML\" class=\"inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors\"><i class=\"fas fa-check mr-1\"></i> Approve</button> <button hx-post=\"")
+		} else {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span class=\"inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800\"><i class=\"fas fa-times-circle mr-1 text-[10px]\"></i> Rejected (Banned)</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</td><!-- Flagged date --><td class=\"px-6 py-4 whitespace-nowrap text-sm text-gray-500 font-mono\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var15 string
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(flag.CreatedAt.Format("2006-01-02 15:04:05"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 132, Col: 49}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><!-- Actions --><td class=\"px-6 py-4 whitespace-nowrap text-right text-sm font-medium\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if flag.Status == "flagged" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"flex justify-end space-x-2\"><button hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/admin/moderation/%d/review", flag.ID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 147, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 140, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-vals='{\"status\": \"rejected\"}' hx-target=\"closest tr\" hx-swap=\"outerHTML\" class=\"inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors\"><i class=\"fas fa-ban mr-1\"></i> Reject</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-vals='{\"status\": \"approved\"}' hx-target=\"closest tr\" hx-swap=\"outerHTML\" class=\"inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors\"><i class=\"fas fa-check mr-1\"></i> Approve</button> <button hx-post=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var17 string
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/admin/moderation/%d/review", flag.ID))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 149, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" hx-vals='{\"status\": \"rejected\"}' hx-target=\"closest tr\" hx-swap=\"outerHTML\" class=\"inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors\"><i class=\"fas fa-ban mr-1\"></i> Reject</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"text-xs text-gray-400 italic\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div class=\"text-xs text-gray-400 italic\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if flag.ReviewedAt != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<span>Reviewed at: ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<span>Reviewed at: ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var17 string
-				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(flag.ReviewedAt.Format("2006-01-02"))
+				var templ_7745c5c3_Var18 string
+				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(flag.ReviewedAt.Format("2006-01-02"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 159, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin/moderation.templ`, Line: 161, Col: 63}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<span>Reviewed</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span>Reviewed</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</td></tr>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</td></tr>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
This PR introduces automatic safety scanning for shortened URLs (supporting Google Web Risk API lookup and local keyword heuristics), automated safety suspension for malicious users/URLs, a CLI subcommand for bulk scanning, and a premium administrative moderation board to review flagged links.

It also includes the fix to make creator usernames clickable on the link moderation page, redirecting administrators directly to the corresponding user details page.