### PR TITLE
fix(stripe): real transactions, idempotent webhooks, hardening

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,22 @@ func (c config) SafeDBString() string {
 	return u.Redacted()
 }
 
+// missingStripeConfig returns the names of any required Stripe settings that are
+// empty. Billing (checkout, webhooks, customer portal) cannot work without them.
+func (c config) missingStripeConfig() []string {
+	var missing []string
+	for name, v := range map[string]string{
+		"stripe-key":             c.StripeKey,
+		"stripe-pub-key":         c.StripePubKey,
+		"stripe-endpoint-secret": c.StripeEndpointSecret,
+	} {
+		if v == "" {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
 var c config
 
 func main() {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -197,6 +197,9 @@ func runServer(ctx context.Context, c config) error {
 		c.GoogleOauthClientID, c.GoogleOauthSecret,
 		c.GithubOauthClientID, c.GithubOauthSecret,
 	)
+	if missing := c.missingStripeConfig(); len(missing) > 0 {
+		log.Error("Stripe is not fully configured, billing will fail", "missing", missing)
+	}
 	stripeService := services.NewStripe(c.StripeKey, subscriptionStore, c.Domain, c.TLS)
 	adminService := services.NewAdministrationService(dbPool, c.redirectURL())
 

--- a/db/datastore/querier.go
+++ b/db/datastore/querier.go
@@ -72,7 +72,7 @@ type Querier interface {
 	UnarchiveURL(ctx context.Context, arg UnarchiveURLParams) error
 	UniqueVisitCount(ctx context.Context, urlID int32) (int64, error)
 	UpdateModerationFlagStatus(ctx context.Context, arg UpdateModerationFlagStatusParams) error
-	UpdateSubscription(ctx context.Context, arg UpdateSubscriptionParams) (Subscription, error)
+	UpdateSubscription(ctx context.Context, arg UpdateSubscriptionParams) error
 	UpdateTitle(ctx context.Context, arg UpdateTitleParams) (Url, error)
 	UpdateURLStatus(ctx context.Context, arg UpdateURLStatusParams) error
 	UpdateUserSuspension(ctx context.Context, arg UpdateUserSuspensionParams) error

--- a/db/datastore/stripe.sql.go
+++ b/db/datastore/stripe.sql.go
@@ -76,6 +76,12 @@ func (q *Queries) InsertCustomer(ctx context.Context, arg InsertCustomerParams) 
 const insertSubscription = `-- name: InsertSubscription :one
 INSERT INTO subscription (stripe_id, customer_id, stripe_price_id, stripe_product_name, status, quantity)
 VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (stripe_id) DO UPDATE SET
+    customer_id = EXCLUDED.customer_id,
+    stripe_price_id = EXCLUDED.stripe_price_id,
+    stripe_product_name = EXCLUDED.stripe_product_name,
+    status = EXCLUDED.status,
+    quantity = EXCLUDED.quantity
 RETURNING stripe_id, customer_id, stripe_price_id, stripe_product_name, status, quantity, created_at, updated_at
 `
 
@@ -153,11 +159,10 @@ func (q *Queries) ListCustomerSubscription(ctx context.Context, arg ListCustomer
 	return items, nil
 }
 
-const updateSubscription = `-- name: UpdateSubscription :one
+const updateSubscription = `-- name: UpdateSubscription :exec
 UPDATE subscription
 SET status = $2, stripe_price_id = $3, stripe_product_name = $4, quantity = $5
 WHERE stripe_id = $1
-RETURNING stripe_id, customer_id, stripe_price_id, stripe_product_name, status, quantity, created_at, updated_at
 `
 
 type UpdateSubscriptionParams struct {
@@ -168,24 +173,13 @@ type UpdateSubscriptionParams struct {
 	Quantity          int32  `json:"quantity"`
 }
 
-func (q *Queries) UpdateSubscription(ctx context.Context, arg UpdateSubscriptionParams) (Subscription, error) {
-	row := q.db.QueryRow(ctx, updateSubscription,
+func (q *Queries) UpdateSubscription(ctx context.Context, arg UpdateSubscriptionParams) error {
+	_, err := q.db.Exec(ctx, updateSubscription,
 		arg.StripeID,
 		arg.Status,
 		arg.StripePriceID,
 		arg.StripeProductName,
 		arg.Quantity,
 	)
-	var i Subscription
-	err := row.Scan(
-		&i.StripeID,
-		&i.CustomerID,
-		&i.StripePriceID,
-		&i.StripeProductName,
-		&i.Status,
-		&i.Quantity,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
+	return err
 }

--- a/db/queries/stripe.sql
+++ b/db/queries/stripe.sql
@@ -19,13 +19,18 @@ RETURNING *;
 -- name: InsertSubscription :one
 INSERT INTO subscription (stripe_id, customer_id, stripe_price_id, stripe_product_name, status, quantity)
 VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (stripe_id) DO UPDATE SET
+    customer_id = EXCLUDED.customer_id,
+    stripe_price_id = EXCLUDED.stripe_price_id,
+    stripe_product_name = EXCLUDED.stripe_product_name,
+    status = EXCLUDED.status,
+    quantity = EXCLUDED.quantity
 RETURNING *;
 
--- name: UpdateSubscription :one
+-- name: UpdateSubscription :exec
 UPDATE subscription
 SET status = $2, stripe_price_id = $3, stripe_product_name = $4, quantity = $5
-WHERE stripe_id = $1
-RETURNING *;
+WHERE stripe_id = $1;
 
 -- name: ListCustomerSubscription :many
 SELECT *

--- a/db/repo_subscriptions.go
+++ b/db/repo_subscriptions.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -13,9 +14,11 @@ import (
 	"github.com/zaibon/shortcut/log"
 )
 
+type txKey struct{}
+
 type repoSubscriptions struct {
 	pool *pgxpool.Pool
-	db   datastore.Querier
+	db   *datastore.Queries
 }
 
 func NewRepoSubscription(db *pgxpool.Pool) *repoSubscriptions {
@@ -25,15 +28,29 @@ func NewRepoSubscription(db *pgxpool.Pool) *repoSubscriptions {
 	}
 }
 
+// q returns the transaction-bound querier when called inside Tx, otherwise the
+// pool-bound one. This is what makes Tx an actual transaction.
+func (r *repoSubscriptions) q(ctx context.Context) *datastore.Queries {
+	if q, ok := ctx.Value(txKey{}).(*datastore.Queries); ok {
+		return q
+	}
+	return r.db
+}
+
 func (r *repoSubscriptions) Tx(ctx context.Context, fn func(context.Context) error, opts pgx.TxOptions) error {
 	tx, err := r.pool.BeginTx(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("error starting transaction: %w", err)
 	}
-	if err := fn(ctx); err != nil {
-		if err := tx.Rollback(ctx); err != nil {
+	defer func() {
+		// no-op if the tx already committed
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
 			log.Error("error rolling back transaction", "err", err)
 		}
+	}()
+
+	ctx = context.WithValue(ctx, txKey{}, r.db.WithTx(tx))
+	if err := fn(ctx); err != nil {
 		return fmt.Errorf("error in transaction: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -43,7 +60,7 @@ func (r *repoSubscriptions) Tx(ctx context.Context, fn func(context.Context) err
 }
 
 func (r *repoSubscriptions) GetCustomer(ctx context.Context, user *domain.User) (datastore.Customer, error) {
-	row, err := r.db.GetCustomer(ctx, user.GUID.PgType())
+	row, err := r.q(ctx).GetCustomer(ctx, user.GUID.PgType())
 	if err != nil {
 		return datastore.Customer{}, fmt.Errorf("error getting customer with id %s: %w", user.GUID, err)
 	}
@@ -51,7 +68,7 @@ func (r *repoSubscriptions) GetCustomer(ctx context.Context, user *domain.User) 
 }
 
 func (r *repoSubscriptions) GetCustomerByStripeId(ctx context.Context, id string) (datastore.Customer, error) {
-	row, err := r.db.GetCustomerByStripeId(ctx, id)
+	row, err := r.q(ctx).GetCustomerByStripeId(ctx, id)
 	if err != nil {
 		return datastore.Customer{}, fmt.Errorf("error getting customer with id %s: %w", id, err)
 	}
@@ -59,7 +76,7 @@ func (r *repoSubscriptions) GetCustomerByStripeId(ctx context.Context, id string
 }
 
 func (r *repoSubscriptions) InsertCustomer(ctx context.Context, customer datastore.InsertCustomerParams) (datastore.Customer, error) {
-	row, err := r.db.InsertCustomer(ctx, customer)
+	row, err := r.q(ctx).InsertCustomer(ctx, customer)
 	if err != nil {
 		return datastore.Customer{}, fmt.Errorf("error inserting customer with id %s: %w", customer.StripeID, err)
 	}
@@ -67,7 +84,7 @@ func (r *repoSubscriptions) InsertCustomer(ctx context.Context, customer datasto
 }
 
 func (r *repoSubscriptions) InsertSubscription(ctx context.Context, subscription datastore.InsertSubscriptionParams) error {
-	_, err := r.db.InsertSubscription(ctx, subscription)
+	_, err := r.q(ctx).InsertSubscription(ctx, subscription)
 	if err != nil {
 		return fmt.Errorf("error inserting subscription with id %s: %w", subscription.StripeID, err)
 	}
@@ -75,7 +92,7 @@ func (r *repoSubscriptions) InsertSubscription(ctx context.Context, subscription
 }
 
 func (r repoSubscriptions) UpdateSubscription(ctx context.Context, subscription datastore.UpdateSubscriptionParams) error {
-	_, err := r.db.UpdateSubscription(ctx, subscription)
+	err := r.q(ctx).UpdateSubscription(ctx, subscription)
 	if err != nil {
 		return fmt.Errorf("error updating subscription with id %s: %w", subscription.StripeID, err)
 	}
@@ -83,8 +100,7 @@ func (r repoSubscriptions) UpdateSubscription(ctx context.Context, subscription 
 }
 
 func (r *repoSubscriptions) ListSubscriptions(ctx context.Context, user *domain.User, status string) ([]datastore.Subscription, error) {
-	log.Info(user.GUID.String())
-	row, err := r.db.ListCustomerSubscription(ctx, datastore.ListCustomerSubscriptionParams{
+	row, err := r.q(ctx).ListCustomerSubscription(ctx, datastore.ListCustomerSubscriptionParams{
 		CustomerID: user.GUID.PgType(),
 		Status: pgtype.Text{
 			String: status,

--- a/db/repo_subscriptions_test.go
+++ b/db/repo_subscriptions_test.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zaibon/shortcut/db/datastore"
+)
+
+// TestRepoSubscriptions_q guards the transaction fix: repo methods must use the
+// tx-bound querier when one is stashed in the context, and the pool-bound one
+// otherwise. If this routing breaks, Tx() silently runs queries outside the
+// transaction (the original bug).
+func TestRepoSubscriptions_q(t *testing.T) {
+	pool := datastore.New(nil)
+	r := &repoSubscriptions{db: pool}
+
+	if got := r.q(context.Background()); got != pool {
+		t.Fatalf("without tx in context: got %p, want pool %p", got, pool)
+	}
+
+	txQ := pool.WithTx(nil)
+	ctx := context.WithValue(context.Background(), txKey{}, txQ)
+	if got := r.q(ctx); got != txQ {
+		t.Fatalf("with tx in context: got %p, want tx querier %p", got, txQ)
+	}
+}

--- a/domain/constants.go
+++ b/domain/constants.go
@@ -1,7 +1,10 @@
 package domain
 
 const (
-	TimeFormat      = "Mon, 02 Jan 06 at 15:04:05"
-	FreePlanLimit   = 10
-	SessionLifetime = 2 * 24 * 60 * 60 // 2 days in seconds
+	TimeFormat    = "Mon, 02 Jan 06 at 15:04:05"
+	FreePlanLimit = 10
+	// UnlimitedPlanLimit is the effective cap for a paid plan that has no
+	// explicit `links` metadata on its Stripe product.
+	UnlimitedPlanLimit = 1000000
+	SessionLifetime    = 2 * 24 * 60 * 60 // 2 days in seconds
 )

--- a/handlers/subscription.go
+++ b/handlers/subscription.go
@@ -78,8 +78,10 @@ func (h *subscriptionHandlers) subscription(w http.ResponseWriter, r *http.Reque
 		planName = sub.Product().Name
 		if sub.Features.LinksNumber > 0 {
 			limit = sub.Features.LinksNumber
-		} else if planName == "Pro" || planName == "Business" {
-			limit = 1000000
+		} else {
+			// ponytail: paid plan with no explicit links cap = unlimited.
+			// Set the `links` metadata on the product to enforce a real limit.
+			limit = domain.UnlimitedPlanLimit
 		}
 	}
 

--- a/services/stripe.go
+++ b/services/stripe.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/zaibon/shortcut/db/datastore"
 	"github.com/zaibon/shortcut/domain"
+	"github.com/zaibon/shortcut/log"
 )
 
 var ErrNotSubscription = errors.New("no subscription found")
@@ -77,6 +78,10 @@ func (s *stripeService) HandleSessionCheckout(ctx context.Context, session *stri
 		if err != nil {
 			return err
 		}
+		if len(sub.Items.Data) == 0 {
+			log.Error("subscription has no items, skipping", "subscription_id", sub.ID)
+			return nil
+		}
 
 		err = s.store.InsertSubscription(ctx, datastore.InsertSubscriptionParams{
 			StripeID:          sub.ID,
@@ -103,6 +108,10 @@ func (s stripeService) HandleSubscriptionUpdated(ctx context.Context, sub *strip
 	sub, err := s.client.Subscriptions.Get(sub.ID, params)
 	if err != nil {
 		return err
+	}
+	if len(sub.Items.Data) == 0 {
+		log.Error("subscription has no items, skipping", "subscription_id", sub.ID)
+		return nil
 	}
 
 	if err := s.store.UpdateSubscription(ctx, datastore.UpdateSubscriptionParams{
@@ -132,6 +141,9 @@ func (s *stripeService) GetSubscription(ctx context.Context, user *domain.User) 
 	sub, err := s.client.Subscriptions.Get(rows[0].StripeID, params)
 	if err != nil {
 		return nil, err
+	}
+	if len(sub.Items.Data) == 0 {
+		return nil, domain.ErrNotSubscriptionItem
 	}
 
 	return domain.NewSubscription(sub), nil


### PR DESCRIPTION
## What

- **Real transactions**: `repoSubscriptions.Tx` now stashes a `WithTx(tx)`-bound querier in context and every method routes through `r.q(ctx)`, so checkout inserts are actually atomic and roll back together. Previously the tx was opened but all queries ran on the pool.
- **Idempotent webhooks**: `InsertSubscription` is now an `ON CONFLICT (stripe_id) DO UPDATE` upsert and `UpdateSubscription` is `:exec`. Redelivered/out-of-order Stripe events no longer 500 and trigger retry storms.
- **Empty-items guards**: `len(sub.Items.Data) == 0` checks at all three `Items.Data[0]` sites; webhooks log + return 200, `GetSubscription` returns `ErrNotSubscriptionItem`.
- **Startup config validation**: warns loudly if any of `stripe-key` / `stripe-pub-key` / `stripe-endpoint-secret` is empty.
- **Metadata-driven plan limits**: removed the hardcoded `"Pro"/"Business"` name check; limit comes from the product's `links` metadata, falling back to unlimited for any paid plan without a cap.
- Removed a stray `log.Info(user.GUID)` that logged a user id on every subscription list.
- Added a dependency-free test guarding the tx-routing logic.

## Why

An audit found the billing flow had two silent data-integrity bugs: the "transaction" wrapper provided no atomicity (a failed subscription insert left an orphaned customer), and webhooks 500'd on Stripe's normal at-least-once redelivery, causing multi-day retry loops. The rest are hardening gaps surfaced in the same pass.

## Design decisions

- **Tx via context**: the repo's `fn(context.Context)` signature meant the cleanest fix was stashing the tx-bound `*datastore.Queries` in context and selecting it in a `q(ctx)` helper, rather than threading a querier through every signature.
- **No customer upsert**: with a real Serializable tx, concurrent duplicate checkout webhooks resolve via serialization-error → Stripe retry → second pass finds the existing customer. Avoids extra upsert machinery.
- **Unlimited fallback for uncapped paid plans**: live "Business" product has no `links` metadata; mapping it to a high cap (rather than Free) avoids downgrading paying users. Set `links` on the product to enforce a real limit.
- **No DB integration test**: the repo has no Postgres test harness; rather than pull in testcontainers/dockertest for one check, the included test verifies the tx-routing selection logic directly. End-to-end is covered via `stripe listen`.

## Operational follow-ups (not code)

- Verified prod Railway env uses **live** keys and the account matches.
- Verify in the live Stripe dashboard that a webhook endpoint targets `https://shct.io/subscription/webhook` with `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted` and a signing secret matching `SHORTCUT_STRIPE_ENDPOINT_SECRET` (MCP can't list endpoints).
- Live "Business" product has empty metadata — set `links` if a hard cap is wanted. Also: Pro is priced at €1.00/mo — confirm that's intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)